### PR TITLE
Disable frontend scaling schedule

### DIFF
--- a/groups/xml-sandpit/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/xml-sandpit/profiles/heritage-staging-eu-west-2/vars
@@ -21,7 +21,7 @@ asg_backend_enable_shutdown_schedule  = true
 asg_frontend_desired_capacity         = 1
 asg_frontend_max_size                 = 1
 asg_frontend_min_size                 = 1
-asg_frontend_enable_shutdown_schedule = true
+asg_frontend_enable_shutdown_schedule = false
 
 cloudwatch_backend_logs = {
   "audit.log" = {


### PR DESCRIPTION
This change disables the scheduled scaling configuration for the frontend EC2 Auto Scaling group to ensure that the service is available 24/7 for external software filers.

Resolves: `DVOP-3600`.